### PR TITLE
Updated to use setuptools so that wheel package can be built.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this. If you cannot, you
+# will need to generate wheels for each Python version that you support.
+universal=0

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from distutils.core import setup
+#!/usr/bin/env python2
+from setuptools import setup
 import sys
 from subprocess import check_call
 from os.path import join, abspath, exists


### PR DESCRIPTION
- updated setup.py to explicitly use python2
- updated setup.py to use setuptools so that a .whl package can be built
- added setup.cfg with one setting saying this is not universal for python2 and python3